### PR TITLE
update コードブロックにシンタックスハイライトを追加

### DIFF
--- a/02.md
+++ b/02.md
@@ -5,7 +5,7 @@
 
 # 文字列を扱ってみる
 
-```
+```cs
 void OnClick_Button(object sender, EventArgs e)
 {
 	string a = "Hello, ";
@@ -22,7 +22,7 @@ void OnClick_Button(object sender, EventArgs e)
 # C# の安全機構
 
 　C# はバグが発生しにくくなるように、安全性を重視して設計された言語である。そのため、以下のようなコードが実行できないようになっている。
-```
+```cs
 （実行に失敗する例）
 void OnClick_Button(object sender, EventArgs e)
 {
@@ -45,7 +45,7 @@ void OnClick_Button(object sender, EventArgs e)
 # 数値を扱ってみる
 
 　ボタンを押したら、1 + 2 の計算結果を表示するようにする。
-```
+```cs
 void OnClick_Button(object sender, EventArgs e)
 {
 	int a = 1;
@@ -75,7 +75,7 @@ void OnClick_Button(object sender, EventArgs e)
 　例として、３つの整数を記憶できる class（＝型）をつくってみる。
 
 
-```
+```cs
 class Test
 {
 	int p;
@@ -89,7 +89,7 @@ class Test
 * (ア) プログラムの中で、class Test が使えるようにする。
 * (イ) ボタンを押したら、Test オブジェクトを生成する。
 
-```
+```cs
 namespace TestProgram
 {
 	// *** (ア) ***
@@ -136,7 +136,7 @@ namespace TestProgram
 
 * (イ) のところで作った Test オブジェクトの p に 1、q に 2 をセットする。
 
-```
+```cs
 （実行に失敗する例）
 void OnClick_Button(object sender, EventArgs e)
 {
@@ -155,7 +155,7 @@ void OnClick_Button(object sender, EventArgs e)
 
 　保護を解除するキーワードが `public` であり、(ア) の部分を以下のようにするとよい。
 
-```
+```cs
 // *** (ア) ***
 class Test
 {
@@ -167,7 +167,7 @@ class Test
 　上記のように、p と q の保護を解除したため、`test.p = 1` などが実行できるようになる。とりあえず実行してエラーが起きないことを確認。
 
 > `public` は制限を解除する、という意味だから、上記のコードにある `public partial class Form1 : Form` も、何らかの制限を解除している。<BR>
-> ```
+> ```cs
 > namespace TestProgram
 > {
 >	public partial class Form1 : Form
@@ -183,7 +183,7 @@ class Test
 
 * p と q を足して、r に結果を代入する関数（メソッドとも言う）を付け足してみる。
 
-```
+```cs
 // *** (ア) ***
 class Test
 {
@@ -197,7 +197,7 @@ class Test
 	}
 }
 ```
-```
+```cs
 void OnClick_Button(object sender, EventArgs e)
 {
 	Test test = new Test();  // *** (イ) ***
@@ -221,7 +221,7 @@ void OnClick_Button(object sender, EventArgs e)
 * r の値を表示してみる
 
 　Test クラスに、r の値を文字列化する機能を加えて、それを `AppendText()` で表示させる。
-```
+```cs
 // *** (ア) ***
 class Test
 {
@@ -240,7 +240,7 @@ class Test
 	}
 }
 ```
-```
+```cs
 void OnClick_Button(object sender, EventArgs e)
 {
 	Test test = new Test();  // *** (イ) ***
@@ -273,7 +273,7 @@ void OnClick_Button(object sender, EventArgs e)
 
 * コンストラクタは、`new` 命令により実行される。（今まで利用していた `new` というのは、コンストラクタの実行を命令していた、ということ。）
 
-```
+```cs
 class Test
 {
 	public Test()  // <- これがコンストラクタの定義
@@ -297,7 +297,7 @@ class Test
 	}
 }
 ```
-```
+```cs
 void OnClick_Button(object sender, EventArgs e)
 {
 	Test test = new Test();
@@ -317,7 +317,7 @@ void OnClick_Button(object sender, EventArgs e)
 
 　コンストラクタには、以下のように引数を与えることができる。
 
-```
+```cs
 class Test
 {
 	public Test(int x, int y)  // <- 引数を持つコンストラクタの定義
@@ -341,7 +341,7 @@ class Test
 	}
 }
 ```
-```
+```cs
 void OnClick_Button(object sender, EventArgs e)
 {
 	Test test = new Test(10, 20);
@@ -357,7 +357,7 @@ void OnClick_Button(object sender, EventArgs e)
 　class を設計する際、多くの部品が必要になることがある。その場合、partial を付けて class の設計を分割することができる。
 
 　以下の２つは同じ意味。
-```
+```cs
 class Test
 {
 	public Test(int x, int y)
@@ -382,7 +382,7 @@ class Test
 }
 ```
 or
-```
+```cs
 public partial class Test
 {
 	public Test(int x, int y)
@@ -419,12 +419,12 @@ public partial class Test
 　実は、今まで使っていた Button や TextBox は、System の中の Windows の中の Forms という区切りの中にある。
 
 　Button や TextBox を作りたい場合、正確に書くと以下のようになる。
-```
+```cs
 System.Windows.Forms.Button btn = new System.Windows.Forms.Button();
 System.Windows.Forms.TextBox text_box = new System.Windows.Forms.TextBox();
 ```
 　当然ながら上のように何度も細かい区切りを書くのが面倒なので、using という命令を利用する。
-```
+```cs
 using System.Windows.Forms;
 
 Button btn = new Button();

--- a/03.md
+++ b/03.md
@@ -5,7 +5,7 @@
 　今まではテキストボックスやボタンを自分で生成するコードを書いていたが、フォームデザイナを利用してテキストボックスとボタンを付け直してみる。
 
 　まず、Form1.cs を初期の状態に戻す。
-```
+```cs
 namespace TestProgram
 {
 	public partial class Form1 : Form
@@ -24,7 +24,7 @@ namespace TestProgram
 > `public partial class Form1 : Form` の行より前に他のクラスの宣言があるとフォームデザイナが利用できなくなるので注意。  
 > 以下のようになっていると、フォームデザイナが起動しない。
 
-```
+```cs
 （フォームデザイナが起動しない例）
 
 namespace TestProgram
@@ -60,7 +60,7 @@ namespace TestProgram
 
 　そうすると、自動的にイベントハンドラ（ボタンを押したときに呼び出される関数）が生成される。Form1.cs に、以下のようなコードが追記される。
 
-```
+```cs
 namespace WindowsFormsApp1
 {
 	public partial class Form1 : Form
@@ -80,7 +80,7 @@ namespace WindowsFormsApp1
 
 　上記の `button1_Click()` の部分に、以下の文を追記する。
 
-```
+```cs
 private void button1_Click(object sender, EventArgs e)
 {
 	this.Close();
@@ -94,7 +94,7 @@ private void button1_Click(object sender, EventArgs e)
 　Form1.Designers.cs を開く。フォームデザイナでボタンが追加されたことで、自動的に追記されたコードは以下の２ヶ所。
 
 (ア) InitializeComponent() の内側
-```
+```cs
 private void InitializeComponent()
 {
 	this.button1 = new System.Windows.Forms.Button();
@@ -113,7 +113,7 @@ private void InitializeComponent()
 ```
 
 (イ) InitializeComponent() の外側にある１行
-```
+```cs
 private System.Windows.Forms.Button button1;
 ```
 
@@ -132,7 +132,7 @@ private System.Windows.Forms.Button button1;
 (3) (イ) の１行を、`private void InitializeComponent() { }` の中に書いてはいけない。
 
 以下のように書くと、関数 `InitializeComponent()` の外側で、`button1` が利用できなくなる。
-```
+```cs
 private void InitializeComponent()
 {
 	System.Windows.Forms.Button button1;  // *** ここに書いてはダメ、ということ ***
@@ -184,7 +184,7 @@ private void InitializeComponent()
 　イベントハンドラの書き方が２通りある。以下の２つの書き方は同じもの、って知っておけばＯＫ（★ の部分が異なるだけ）。
 
 * (1)
-```
+```cs
 class Form1 : Form
 {
 	Button btn = new Button()
@@ -200,7 +200,7 @@ class Form1 : Form
 }
 ```
 * (2)
-```
+```cs
 class Form1 : Form
 {
 	Button btn = new Button()

--- a/readme.md
+++ b/readme.md
@@ -32,7 +32,7 @@ https://qiita.com/grinpeaceman/items/b5a6082f94c9e4891613
 　できあがるファイルで重要なのは下の３つだけ。namespace のところに表示されるものは、プロジェクトを作成する時に付けた名前になっていると思う。
 
 (ア) Program.cs（ソリューションエクスプローラで、Program.cs をダブルクリック）
-```
+```cs
 namespace TestProgram
 {
 	static class Program
@@ -49,7 +49,7 @@ namespace TestProgram
 ```
 
 (イ) Form1.cs（ソリューションエクスプローラで Form1.cs を右クリックして、「コードの表示」をクリック）
-```
+```cs
 namespace TestProgram
 {
 	public partial class Form1 : Form
@@ -63,7 +63,7 @@ namespace TestProgram
 ```
 
 (ウ) Form1.Designers.cs（ソリューションエクスプローラで、Forms1.cs の左側の ▶ マークをクリックすると、Form1.Designers.cs が表示されるので、それをダブルクリック）
-```
+```cs
 namespace TestProgram
 {
 	partial class Form1
@@ -105,7 +105,7 @@ namespace TestProgram
 * C# は、プログラム中にある `static void Main()` から実行が開始される、という仕様になっている。だから、(ア) の `static void Main()` からプログラムが開始される。
 
 * 以下の２つは、描画関連の内部スイッチの変更。時間に余裕があるときに、ネットで調べると良いと思う。詳細を知ったとしても、特に変更するものではないものだと思う。
-```
+```cs
 Application.EnableVisualStyles();
 Application.SetCompatibleTextRenderingDefault(false);
 ```
@@ -126,7 +126,7 @@ Application.SetCompatibleTextRenderingDefault(false);
 >　`class A { ... }` とすると、`...` の部分が「A を構成する部品」という意味になるよ。「class」は、１つのまとまったものを表す。学校での「クラス」と同じ概念。
 >
 >　以下のように書くと、`Form1` というクラスの中に、`Form1()` という関数があるという意味になる。
-> ```
+> ```cs
 > class Form1
 > {
 >	Form1()
@@ -157,7 +157,7 @@ Application.SetCompatibleTextRenderingDefault(false);
 
 　とりあえず、以下のようにコードを書き足して、F5 キーで実行させてみて欲しい。
 
-```
+```cs
 namespace TestProgram
 {
 	public partial class Form1 : Form
@@ -187,12 +187,12 @@ namespace TestProgram
 * 「名前を付ける」のと、「new で生成する」のを２行に分けて書くのが面倒くさい場合は、まとめることができる。以下の (a) と (b) は同じ意味になる。
 
 (a)
-```
+```cs
 TextBox text_box;
 text_box = new TextBox();
 ```
 (b)
-```
+```cs
 TextBox text_box = new TextBox();
 ```
 
@@ -214,20 +214,20 @@ TextBox text_box = new TextBox();
 　C# では、名前を決めて、new で生成して、それを渡したり操作したりする、という感覚が必要。位置を指定するためだけに、 **「位置という情報を作成する」** 必要がある。  
   さっきのサイズ設定と同じ感覚。
 
-```
+```cs
 Point box_pos;　　　　　　　　　// 名前を決める
 box_pos = new Point(50, 50);　// new で生成する
 
 text_box.Location = box_pos;　// 作った位置（Point）を渡す
 ```
 または、
-```
+```cs
 text_box.Location = new Point(50, 50);  // new で生成したものを、直接渡すこともできる
 ```
 
 # ボタンを追加してみる
 
-```
+```cs
 namespace TestProgram
 {
 	public partial class Form1 : Form
@@ -258,7 +258,7 @@ namespace TestProgram
 * ウィンドウを閉じるときは、Form に Close() を命令すればよい。
 * Button クラスで作成されたオブジェクト（＝部品）は、ボタンが押されると Click に設定されたメソッド（＝関数）を呼び出す。
 
-```
+```cs
 namespace TestProgram
 {
 	public partial class Form1 : Form
@@ -297,7 +297,7 @@ namespace TestProgram
 
 * テキストボックスに、メッセージを追加表示させたい場合は `AppendText()` という命令を使う。
 * 考え方としては以下のようになるけれど、以下のままではエラーとなる。
-```
+```cs
 namespace TestProgram
 {
 	public partial class Form1 : Form
@@ -341,7 +341,7 @@ namespace TestProgram
 
 　名前の有効範囲を広めるために、{ } の外側で名前を宣言する。
 
-```
+```cs
 namespace TestProgram
 {
 	public partial class Form1 : Form
@@ -378,7 +378,7 @@ namespace TestProgram
 ```
 　名前を作ると同時に new をすることもできるから、以下のように書いてもよい。（`new TextBox();` の場所が変わっただけ）
 
-```
+```cs
 namespace TestProgram
 {
 	public partial class Form1 : Form


### PR DESCRIPTION
お久しぶりです、py です。
CS の解説、拝見させていただきました。

マークダウンのコードブロックに言語を指定すると、  
![preview](https://user-images.githubusercontent.com/52993483/106828211-15807100-66cd-11eb-9343-7afc3841f21c.png)  
の様に GitHub 上でシンタックスハイライトされてプレビューされるため、見やすくなるかと思い編集いたしました。

以下のファイルのコードブロックの言語に `cs` を指定しています。
- 02.md
- 03.md
- readme.md

よろしければマージしていただければと思います。